### PR TITLE
Vagrant should no longer be installed as a gem but using the package …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,0 @@
-source :rubygems
-
-gem 'berkshelf'
-gem 'vagrant', '~> 1.0.5'

--- a/README.rdoc
+++ b/README.rdoc
@@ -15,23 +15,22 @@ http://www.magentocommerce.com/wiki/how_to_fix_login_for_admin_on_local_install
 
 - virtualbox
 
+- vagrant
+
 - ruby 1.9.3
 
-- bundler (ruby gem)
 
 = INSTALLATION:
 
 Get the vagrant recipe with the following command:
 
     git clone https://github.com/akretion/ak-magento.git
+    
+Install ``vagrant`` from the package manager of your distribution or from http://downloads.vagrantup.com/
 
-If you do not have bundler, install it with:
+Install ``berkshelf`` in vagrant using:
 
-    gem install bundler
-
-Install the required gems with:
-
-    bundle install
+    vagrant gem install vagrant-berkshelf
 
 Then go in the ak-magento directory and launch vagrant:
 


### PR DESCRIPTION
...manager. Fixes #3

See https://github.com/akretion/ak-magento/issues/3 for more information

Removed Gemfile because vagrant refuses to run in a bundled environment
